### PR TITLE
changed Parse class to be an interface and added getter/setter for it in...

### DIFF
--- a/SocketIO/Scripts/SocketIO/Parser.cs
+++ b/SocketIO/Scripts/SocketIO/Parser.cs
@@ -29,7 +29,12 @@ using UnityEngine;
 
 namespace SocketIO
 {
-	public class Parser
+    public interface Parser
+    {
+        SocketIOEvent Parse(JSONObject json);
+    }
+
+	public class DefaultParser : Parser
 	{
 		public SocketIOEvent Parse(JSONObject json)
 		{

--- a/SocketIO/Scripts/SocketIO/SocketIOComponent.cs
+++ b/SocketIO/Scripts/SocketIO/SocketIOComponent.cs
@@ -53,6 +53,12 @@ namespace SocketIO
 		public string sid { get; set; }
 		public bool IsConnected { get { return connected; } }
 
+        public Parser Parser
+        {
+            get { return parser; }
+            set { parser = value; }
+        }
+
 		#endregion
 
 		#region Private Properties
@@ -93,7 +99,7 @@ namespace SocketIO
 		{
 			encoder = new Encoder();
 			decoder = new Decoder();
-			parser = new Parser();
+			parser = new DefaultParser();
 			handlers = new Dictionary<string, List<Action<SocketIOEvent>>>();
 			ackList = new List<Ack>();
 			sid = null;


### PR DESCRIPTION
I wish to support messages that have a string payload, but the current Parser class throws an exception if it is not of type OBJECT.

Is there a real reason for this exception?

I would propose transforming the `Parser` class into an interface. I created  a `DefaultParser` class that is used in `SocketIOComponent.Awake()`, and also added a getter/setter for the parser so that the user can override it with a custom class if his own.

How do you find these changes?

Thanks