### PR TITLE
Add support for emitting and receiving strings

### DIFF
--- a/SocketIO/Scripts/SocketIO/Parser.cs
+++ b/SocketIO/Scripts/SocketIO/Parser.cs
@@ -45,11 +45,11 @@ namespace SocketIO
 				return new SocketIOEvent(json[0].str);
 			} 
 
-			if (json[1].type != JSONObject.Type.OBJECT) {
-				throw new SocketIOException("Invalid argument type. " + json[1].type + " received while expecting " + JSONObject.Type.OBJECT);
+			if (json[1].type == JSONObject.Type.OBJECT || json[1].type == JSONObject.Type.STRING) {
+				return new SocketIOEvent(json[0].str, json[1]);
+			} else {
+				throw new SocketIOException("Invalid argument type. " + json[1].type + " received");
 			}
-
-			return new SocketIOEvent(json[0].str, json[1]);
 		}
 	}
 }

--- a/SocketIO/Scripts/SocketIO/SocketIOComponent.cs
+++ b/SocketIO/Scripts/SocketIO/SocketIOComponent.cs
@@ -231,6 +231,11 @@ namespace SocketIO
 			ackList.Add(new Ack(packetId, action));
 		}
 
+		public void Emit(string ev, string str)
+		{
+			EmitMessage(-1, string.Format("[\"{0}\",\"{1}\"]", ev, str));
+		}
+
 		public void Emit(string ev, JSONObject data)
 		{
 			EmitMessage(-1, string.Format("[\"{0}\",{1}]", ev, data));


### PR DESCRIPTION
Emitting a standalone string is a valid and functional way to transmit and receive data using SocketIO. A documented example of such usage can be found [here](http://socket.io/docs/migrating-from-0-9/#shortcuts).